### PR TITLE
Fix NoneType casting error

### DIFF
--- a/onionperf/analysis.py
+++ b/onionperf/analysis.py
@@ -204,7 +204,7 @@ class Analysis(object):
                         srcport = int(xfer_db['endpoint_local'].split(':')[2])
                         if srcport in streams_by_srcport:
                             stream_db = streams_by_srcport[srcport]
-                            circid = int(stream_db['circuit_id'])
+                            circid = int(stream_db['circuit_id'] or 0)
                             if circid in circuits:
                                 circuit_db = circuits[circid]
 


### PR DESCRIPTION
Hi,

This should fix the following error when analysing data as per issue #28:

```
onionperf analyze -t --tgen=tgen-client/log_archive/onionperf_2017-03-15_23\:59\:59.tgen.log --torctl=tor-client/log_archive/onionperf_2017-03-15_23\:59\:59.torctl.log -p=twistd/docroot/
2017-03-20 09:50:02 1490003402.446086 [onionperf] [INFO] parsing log file at /home/cloud/onionperf/onionperf-data/tgen-client/log_archive/onionperf_2017-03-15_23:59:59.tgen.log
2017-03-20 09:50:03 1490003403.142353 [onionperf] [INFO] parsing log file at /home/cloud/onionperf/onionperf-data/tor-client/log_archive/onionperf_2017-03-15_23:59:59.torctl.log
545 795
2017-03-20 09:50:15 1490003415.877429 [onionperf] [INFO] saving analysis results to /home/cloud/onionperf/onionperf-data/twistd/docroot/onionperf.analysis.json.xz
2017-03-20 09:50:24 1490003424.114065 [onionperf] [INFO] done!
2017-03-20 09:50:24 1490003424.114919 [onionperf] [INFO] saving analysis results to /home/cloud/onionperf/onionperf-data/twistd/docroot/op-us-5242880-2017-03-20.tpf.xz
Traceback (most recent call last):
  File "/usr/local/bin/onionperf", line 472, in <module>
    if __name__ == '__main__': sys.exit(main())
  File "/usr/local/bin/onionperf", line 318, in main
    args.func(args)
  File "/usr/local/bin/onionperf", line 392, in analyze
    analysis.export_torperf_version_1_0(output_prefix=args.prefix, do_compress=True)
  File "/usr/local/lib/python2.7/dist-packages/onionperf/analysis.py", line 207, in export_torperf_version_1_0
    circid = int(stream_db['circuit_id'])
TypeError: int() argument must be a string or a number, not 'NoneType'
```

Please let me know what you think.